### PR TITLE
change use command to run command

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -24,7 +24,7 @@ jobs:
     - name: run JSDoc
       run: npx jsdoc -r ./source -d ./docs
     - name: run Code Quality
-      uses: echo "synced Code Climate to repository, check pull request to see feedback from Code Climate"
+      run: echo "synced Code Climate to repository, check pull request to see feedback from Code Climate"
     - name: run Jest Tests
       run: npm run test
     - name: check Jest test coverage


### PR DESCRIPTION
From the push that was just made to main, used the use command instead of the run command in one of the steps of the pipeline in main.yaml. Hard to catch because pipeline ran successfully even with the bug and didn't know about bug until it was merged to main.