### PR TITLE
handled edge cases with collapsing side bar

### DIFF
--- a/source/scripts/main.js
+++ b/source/scripts/main.js
@@ -30,10 +30,13 @@ document.addEventListener("DOMContentLoaded", () => {
       '<img src="/source/images/create_white.svg" alt="create_image" height="22">';
     createBtn.style.width = 0;
     filterBtn.textContent = "";
+    summaryDateEl.parentElement.removeAttribute("open");
+    summaryLabelEl.parentElement.removeAttribute("open");
     summaryDateEl.style = "display:none";
     summaryLabelEl.style = "display:none";
     mainEl.style.gridTemplateColumns = "4.5rem auto";
   }
+  shrink();
   collapseBtn.addEventListener("click", () => {
     // Collapse button textcontent to >
     if (collapseBtn.textContent == "<") {

--- a/source/tests/end2end.test.js
+++ b/source/tests/end2end.test.js
@@ -129,6 +129,8 @@ describe("Test Delete Functionality", () => {
     for (let i = 0; i < posts.length; i++) {
       post_totals[posts[i]["label"]] += 1;
     }
+    let collapse_side_button = await page.$("#collapse_button");
+    await collapse_side_button.click();
     //Open Drop Down:
     let dropDown = await page.$("#label_option");
     await dropDown.click();


### PR DESCRIPTION
Two edge cases with collapsing bar handled:

1. Before when the page first loaded, the side base would be expanded and the ">" wouldn't show. Now, the side bar is collapsed when you first load the page and you can only expand it when you click on the ">" 
2. Before if the side bar was expanded and either label or date (or both) was expanded when you went to click  "<" to collapse the side bar the expanded options in label and/or date would stay. Now, even if the options are expanded from label and/or date, if the "<" is clicked to collapse thee side bar then everything else is also shrunk (if label has options showing, those options are hidden; if date has the two text boxes showing to input to and from dates those are hidden)