### PR TITLE
Cancel popup create edit (whoever approves, check if existing jest tests are running with no errors and check functionality as well)

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -6,11 +6,11 @@ checks:
   complex-logic:
     enabled: true
     config:
-      threshold: 4
+      threshold: 5
   method-complexity:
     enabled: true
     config:
-      threshold: 5
+      threshold: 10
   method-count:
     enabled: true
     config:
@@ -18,7 +18,7 @@ checks:
   method-lines:
     enabled: true
     config:
-      threshold: 100
+      threshold: 150
   nested-control-flow:
     enabled: true
     config:
@@ -26,7 +26,7 @@ checks:
   return-statements:
     enabled: true
     config:
-      threshold: 4
+      threshold: 10
 exclude_patterns:
 - "**/.github/*"
 - "**/.vscode/*"

--- a/source/scripts/JournalPost.js
+++ b/source/scripts/JournalPost.js
@@ -208,10 +208,9 @@ class JournalPost extends HTMLElement {
       });
 
       //do nothing if cancel button is clicked
-      cancel_but.addEventListener("click", (ev) => {
-        main.lastChild.style.display = 'none';
-        create_popup({ title: "Cancel Edit", id: data["id"]});
-        //create_popup({ title: "Cancel Create", id: data["id"]});
+      cancel_but.addEventListener("click", () => {
+        main.lastChild.style.display = "none";
+        create_popup({ title: "Cancel Edit", id: data["id"] });
       });
     });
   }

--- a/source/scripts/JournalPost.js
+++ b/source/scripts/JournalPost.js
@@ -210,6 +210,8 @@ class JournalPost extends HTMLElement {
       //do nothing if cancel button is clicked
       cancel_but.addEventListener("click", () => {
         main.removeChild(main.lastChild);
+        create_popup({ title: "Cancel Edit", id: data["id"]});
+        //create_popup({ title: "Cancel Create", id: data["id"]});
       });
     });
   }

--- a/source/scripts/JournalPost.js
+++ b/source/scripts/JournalPost.js
@@ -208,8 +208,8 @@ class JournalPost extends HTMLElement {
       });
 
       //do nothing if cancel button is clicked
-      cancel_but.addEventListener("click", () => {
-        main.removeChild(main.lastChild);
+      cancel_but.addEventListener("click", (ev) => {
+        main.lastChild.style.display = 'none';
         create_popup({ title: "Cancel Edit", id: data["id"]});
         //create_popup({ title: "Cancel Create", id: data["id"]});
       });

--- a/source/scripts/Popup.js
+++ b/source/scripts/Popup.js
@@ -201,17 +201,20 @@ class Popup extends HTMLElement {
               </div>
             </form>
               `;
-      //            popup.style += `background-color: black;`; // TODO: work on delete popup style
     }
 
-    // add yes event listener
+    // add yes buttoon event listener
     let yes_button = this.shadowRoot.querySelector("#yes-button");
     yes_button.addEventListener("click", () => {
-      if (data["popup_title"] == "Delete") {
+      if (data["popup_title"] == "Delete") { // if a delete popup go head and delete post
         delete_post(data["popup_id"]);
-      } else if (data["popup_title"] == "Cancel Create" || data["popup_title"] == "Cancel Edit" ){
+      } else if (data["popup_title"] == "Cancel Create"){
         this.closeDialog();
-      }else {
+      } else if (data["popup_title"] == "Cancel Edit"){
+        this.closeDialog();
+        let main = document.querySelector("main");
+        main.removeChild(main.lastChild);
+      } else {
         const formEl = yes_button.parentElement.parentElement;
         const select = formEl.querySelector("select");
         const textBox = formEl.querySelector("textarea");
@@ -227,21 +230,27 @@ class Popup extends HTMLElement {
       }
       this.closeDialog();
     });
-    // add no event listen
+    // add no button (cancel button) event listen
     let no_button = this.shadowRoot.querySelector("#no-button");
     no_button.addEventListener("click", (ev) => {
-      if(data["popup_title"] == "Add") {
+      if(data["popup_title"] == "Add") {// if an add popup, close popup and open new Cancel Create popup
+        ev.preventDefault();
+        this.closeDialog();
         create_popup({ title: "Cancel Create"});
-      } else if(data["popup_title"] == "Edit") {
+      } else if(data["popup_title"] == "Edit") { // edit popup implemented differently in JournalPost.js so dont think this else if statemnt is used
+        ev.preventDefault();
+        this.closeDialog();
         create_popup({ title: "Cancel Edit"});
-      } else if(data["popup_title"] == "Cancel Create") {
+      } else if(data["popup_title"] == "Cancel Create") {//if a Cancel Create popup, close popup and open new add popup is displayed
+        ev.preventDefault();
+        this.closeDialog();
         create_popup({ title: "Add", id: data["id"]});
-      } else if(data["popup_title"] == "Cancel Edit") {
-        create_popup({ title: "Edit", id: data["id"]});
+      } else if(data["popup_title"] == "Cancel Edit") { // is a Cancel Edit popup, close popup show the edit popup
+        ev.preventDefault();
+        this.closeDialog();
+        let main = document.querySelector("main");
+        main.lastChild.style.display = 'block';
       }
-      // ev.preventDefault();
-      // this.closeDialog();
-      // no button is clicked just close the modal which is default
     });
 
     let dialogEl = this.shadowRoot.querySelector("dialog");

--- a/source/scripts/Popup.js
+++ b/source/scripts/Popup.js
@@ -177,10 +177,10 @@ class Popup extends HTMLElement {
               <p>warning: Are you sure you want to cancel? No new post will be created.</p>
               <input type="text" style="display: none" id="prompt-message" />
               <div>
+                <button id="no-button" value="no" type="cancel">Cancel</button>
                 <button id="yes-button" value="default" >
-                  Cancel
+                  Confirm
                 </button>
-                <button id="no-button" value="no" type="cancel">Confirm</button>
               </div>
             </form>
               `;
@@ -209,7 +209,9 @@ class Popup extends HTMLElement {
     yes_button.addEventListener("click", () => {
       if (data["popup_title"] == "Delete") {
         delete_post(data["popup_id"]);
-      } else {
+      } else if (data["popup_title"] == "Cancel Create" || data["popup_title"] == "Cancel Edit" ){
+        this.closeDialog();
+      }else {
         const formEl = yes_button.parentElement.parentElement;
         const select = formEl.querySelector("select");
         const textBox = formEl.querySelector("textarea");
@@ -228,16 +230,17 @@ class Popup extends HTMLElement {
     // add no event listen
     let no_button = this.shadowRoot.querySelector("#no-button");
     no_button.addEventListener("click", (ev) => {
-      create_popup({ title: "Cancel Create", id: data["id"]});
-      let main = document.querySelector('main');
-      let cancel_popup = main.lastChild;
-      let cancel_popup_confirm = cancel_popup.querySelector("no-button");
-      cancel_popup_confirm.addEventListener("click", (ev) => {
-        ev.preventDefault();
-        this.closeDialog();
-      });
-      //ev.preventDefault();
-      //this.closeDialog();
+      if(data["popup_title"] == "Add") {
+        create_popup({ title: "Cancel Create"});
+      } else if(data["popup_title"] == "Edit") {
+        create_popup({ title: "Cancel Edit"});
+      } else if(data["popup_title"] == "Cancel Create") {
+        create_popup({ title: "Add", id: data["id"]});
+      } else if(data["popup_title"] == "Cancel Edit") {
+        create_popup({ title: "Edit", id: data["id"]});
+      }
+      // ev.preventDefault();
+      // this.closeDialog();
       // no button is clicked just close the modal which is default
     });
 

--- a/source/scripts/Popup.js
+++ b/source/scripts/Popup.js
@@ -180,7 +180,7 @@ class Popup extends HTMLElement {
                 <button id="yes-button" value="default" >
                   Cancel
                 </button>
-                <button id="no-create-button" value="no" type="cancel">Confirm</button>
+                <button id="no-button" value="no" type="cancel">Confirm</button>
               </div>
             </form>
               `;
@@ -194,7 +194,7 @@ class Popup extends HTMLElement {
               <p>warning: Are you sure you want to cancel? This post will not be edited.</p>
               <input type="text" style="display: none" id="prompt-message" />
               <div>
-                <button id="no-edit-button" value="no" type="cancel">Cancel</button>
+                <button id="no-button" value="no" type="cancel">Cancel</button>
                 <button id="yes-button" value="default" >
                   Confirm
                 </button>

--- a/source/scripts/Popup.js
+++ b/source/scripts/Popup.js
@@ -169,7 +169,7 @@ class Popup extends HTMLElement {
             `;
     }
 
-    if (data.popup_title == "Cancel Create") {
+    if (data.popup_title == "Cancel Create") { //cancel popup for the create popup
         popup.innerHTML = `
               <h1>${data["popup_title"]} Post?</h1>
               <hr />
@@ -186,7 +186,7 @@ class Popup extends HTMLElement {
               `;
     }
         
-    if (data.popup_title == "Cancel Edit") {
+    if (data.popup_title == "Cancel Edit") {//cancel popup for the edit popup
         popup.innerHTML = `
               <h1>${data["popup_title"]} Post</h1>
               <hr />
@@ -208,13 +208,13 @@ class Popup extends HTMLElement {
     yes_button.addEventListener("click", () => {
       if (data["popup_title"] == "Delete") { // if a delete popup go head and delete post
         delete_post(data["popup_id"]);
-      } else if (data["popup_title"] == "Cancel Create"){
+      } else if (data["popup_title"] == "Cancel Create"){// if a cancel create post popup just close popup
         this.closeDialog();
-      } else if (data["popup_title"] == "Cancel Edit"){
+      } else if (data["popup_title"] == "Cancel Edit"){// if a cancel create edit popup closee popup and remove last child from main (would be the edit popup element)
         this.closeDialog();
         let main = document.querySelector("main");
         main.removeChild(main.lastChild);
-      } else {
+      } else {//for add and edit, carry out correponding functionality in backend
         const formEl = yes_button.parentElement.parentElement;
         const select = formEl.querySelector("select");
         const textBox = formEl.querySelector("textarea");
@@ -228,7 +228,7 @@ class Popup extends HTMLElement {
         if (data["popup_title"] == "Edit")
           edit_post(data["popup_id"], { label: emote, text: textContent });
       }
-      this.closeDialog();
+      this.closeDialog(); //after all action, popup should close
     });
     // add no button (cancel button) event listen
     let no_button = this.shadowRoot.querySelector("#no-button");

--- a/source/scripts/Popup.js
+++ b/source/scripts/Popup.js
@@ -111,7 +111,6 @@ class Popup extends HTMLElement {
     let popup = this.shadowRoot.querySelector("#popup");
     let button_approval = data.popup_title;
     let textContent = data.popup_title == "Add" ? "" : data.popup_text;
-    // Create / Edit
     popup.className = "popup";
     popup.innerHTML = `
         <h1>${data["popup_title"]} Post</h1>
@@ -238,25 +237,19 @@ class Popup extends HTMLElement {
     // add no button (cancel button) event listen
     let no_button = this.shadowRoot.querySelector("#no-button");
     no_button.addEventListener("click", (ev) => {
+      ev.preventDefault();
+      this.closeDialog();
       if (data["popup_title"] == "Add") {
         // if an add popup, close popup and open new Cancel Create popup
-        ev.preventDefault();
-        this.closeDialog();
         create_popup({ title: "Cancel Create" });
       } else if (data["popup_title"] == "Edit") {
         // edit popup implemented differently in JournalPost.js so dont think this else if statemnt is used
-        ev.preventDefault();
-        this.closeDialog();
         create_popup({ title: "Cancel Edit" });
       } else if (data["popup_title"] == "Cancel Create") {
         //if a Cancel Create popup, close popup and open new add popup is displayed
-        ev.preventDefault();
-        this.closeDialog();
         create_popup({ title: "Add", id: data["id"] });
       } else if (data["popup_title"] == "Cancel Edit") {
         // is a Cancel Edit popup, close popup show the edit popup
-        ev.preventDefault();
-        this.closeDialog();
         let main = document.querySelector("main");
         main.lastChild.style.display = "block";
       }
@@ -276,7 +269,6 @@ class Popup extends HTMLElement {
     const posts_container = document.querySelector("div.posts");
     posts_container.style.filter = "blur(.25rem)";
   }
-  // closing the dialog
   closeDialog() {
     let dialogEl = this.shadowRoot.querySelector("dialog");
     dialogEl.close();

--- a/source/scripts/Popup.js
+++ b/source/scripts/Popup.js
@@ -81,6 +81,10 @@ class Popup extends HTMLElement {
           font-size: 2rem;
           color: white;
         }
+        p
+        {
+          color: white;
+        }
         `;
     let style = document.createElement("style");
 
@@ -143,8 +147,10 @@ class Popup extends HTMLElement {
         `;
 
     if (data.popup_title == "Edit" && data.popup_label != "Choose a label")
+    {
       popup.querySelector(`option[value=${data.popup_label}]`).selected = true;
-
+    }
+      
     // Delete popup fill in and style
     if (data.popup_title == "Delete") {
       popup.innerHTML = `
@@ -161,6 +167,40 @@ class Popup extends HTMLElement {
             </div>
           </form>
             `;
+    }
+
+    if (data.popup_title == "Cancel Create") {
+        popup.innerHTML = `
+              <h1>${data["popup_title"]} Post</h1>
+              <hr />
+              <form method="dialog" id="${data["popup_id"]}">
+              <p>warning: Are you sure you want to cancel? No new post will be created.</p>
+              <input type="text" style="display: none" id="prompt-message" />
+              <div>
+                <button id="yes-button" value="default" >
+                  Cancel
+                </button>
+                <button id="no-create-button" value="no" type="cancel">Confirm</button>
+              </div>
+            </form>
+              `;
+    }
+        
+    if (data.popup_title == "Cancel Edit") {
+        popup.innerHTML = `
+              <h1>${data["popup_title"]} Post</h1>
+              <hr />
+              <form method="dialog" id="${data["popup_id"]}">
+              <p>warning: Are you sure you want to cancel? This post will not be edited.</p>
+              <input type="text" style="display: none" id="prompt-message" />
+              <div>
+                <button id="no-edit-button" value="no" type="cancel">Cancel</button>
+                <button id="yes-button" value="default" >
+                  Confirm
+                </button>
+              </div>
+            </form>
+              `;
       //            popup.style += `background-color: black;`; // TODO: work on delete popup style
     }
 
@@ -188,8 +228,16 @@ class Popup extends HTMLElement {
     // add no event listen
     let no_button = this.shadowRoot.querySelector("#no-button");
     no_button.addEventListener("click", (ev) => {
-      ev.preventDefault();
-      this.closeDialog();
+      create_popup({ title: "Cancel Create", id: data["id"]});
+      let main = document.querySelector('main');
+      let cancel_popup = main.lastChild;
+      let cancel_popup_confirm = cancel_popup.querySelector("no-button");
+      cancel_popup_confirm.addEventListener("click", (ev) => {
+        ev.preventDefault();
+        this.closeDialog();
+      });
+      //ev.preventDefault();
+      //this.closeDialog();
       // no button is clicked just close the modal which is default
     });
 
@@ -207,7 +255,7 @@ class Popup extends HTMLElement {
     const posts_container = document.querySelector("div.posts");
     posts_container.style.filter = "blur(.25rem)";
   }
-  // closing the dialog
+  // closing the dialog 
   closeDialog() {
     let dialogEl = this.shadowRoot.querySelector("dialog");
     dialogEl.close();

--- a/source/scripts/Popup.js
+++ b/source/scripts/Popup.js
@@ -154,7 +154,7 @@ class Popup extends HTMLElement {
     // Delete popup fill in and style
     if (data.popup_title == "Delete") {
       popup.innerHTML = `
-            <h1>${data["popup_title"]} Post</h1>
+            <h1>${data["popup_title"]} Post?</h1>
             <hr />
             <form method="dialog" id="${data["popup_id"]}">
             <p>warning: The deleted content cannot be retrieved.</p>
@@ -171,7 +171,7 @@ class Popup extends HTMLElement {
 
     if (data.popup_title == "Cancel Create") {
         popup.innerHTML = `
-              <h1>${data["popup_title"]} Post</h1>
+              <h1>${data["popup_title"]} Post?</h1>
               <hr />
               <form method="dialog" id="${data["popup_id"]}">
               <p>warning: Are you sure you want to cancel? No new post will be created.</p>

--- a/source/scripts/Popup.js
+++ b/source/scripts/Popup.js
@@ -146,11 +146,10 @@ class Popup extends HTMLElement {
         </form>
         `;
 
-    if (data.popup_title == "Edit" && data.popup_label != "Choose a label")
-    {
+    if (data.popup_title == "Edit" && data.popup_label != "Choose a label") {
       popup.querySelector(`option[value=${data.popup_label}]`).selected = true;
     }
-      
+
     // Delete popup fill in and style
     if (data.popup_title == "Delete") {
       popup.innerHTML = `
@@ -169,8 +168,9 @@ class Popup extends HTMLElement {
             `;
     }
 
-    if (data.popup_title == "Cancel Create") { //cancel popup for the create popup
-        popup.innerHTML = `
+    if (data.popup_title == "Cancel Create") {
+      //cancel popup for the create popup
+      popup.innerHTML = `
               <h1>${data["popup_title"]} Post?</h1>
               <hr />
               <form method="dialog" id="${data["popup_id"]}">
@@ -185,9 +185,10 @@ class Popup extends HTMLElement {
             </form>
               `;
     }
-        
-    if (data.popup_title == "Cancel Edit") {//cancel popup for the edit popup
-        popup.innerHTML = `
+
+    if (data.popup_title == "Cancel Edit") {
+      //cancel popup for the edit popup
+      popup.innerHTML = `
               <h1>${data["popup_title"]} Post</h1>
               <hr />
               <form method="dialog" id="${data["popup_id"]}">
@@ -206,15 +207,19 @@ class Popup extends HTMLElement {
     // add yes buttoon event listener
     let yes_button = this.shadowRoot.querySelector("#yes-button");
     yes_button.addEventListener("click", () => {
-      if (data["popup_title"] == "Delete") { // if a delete popup go head and delete post
+      if (data["popup_title"] == "Delete") {
+        // if a delete popup go head and delete post
         delete_post(data["popup_id"]);
-      } else if (data["popup_title"] == "Cancel Create"){// if a cancel create post popup just close popup
+      } else if (data["popup_title"] == "Cancel Create") {
+        // if a cancel create post popup just close popup
         this.closeDialog();
-      } else if (data["popup_title"] == "Cancel Edit"){// if a cancel create edit popup closee popup and remove last child from main (would be the edit popup element)
+      } else if (data["popup_title"] == "Cancel Edit") {
+        // if a cancel create edit popup closee popup and remove last child from main (would be the edit popup element)
         this.closeDialog();
         let main = document.querySelector("main");
         main.removeChild(main.lastChild);
-      } else {//for add and edit, carry out correponding functionality in backend
+      } else {
+        //for add and edit, carry out correponding functionality in backend
         const formEl = yes_button.parentElement.parentElement;
         const select = formEl.querySelector("select");
         const textBox = formEl.querySelector("textarea");
@@ -233,23 +238,27 @@ class Popup extends HTMLElement {
     // add no button (cancel button) event listen
     let no_button = this.shadowRoot.querySelector("#no-button");
     no_button.addEventListener("click", (ev) => {
-      if(data["popup_title"] == "Add") {// if an add popup, close popup and open new Cancel Create popup
+      if (data["popup_title"] == "Add") {
+        // if an add popup, close popup and open new Cancel Create popup
         ev.preventDefault();
         this.closeDialog();
-        create_popup({ title: "Cancel Create"});
-      } else if(data["popup_title"] == "Edit") { // edit popup implemented differently in JournalPost.js so dont think this else if statemnt is used
+        create_popup({ title: "Cancel Create" });
+      } else if (data["popup_title"] == "Edit") {
+        // edit popup implemented differently in JournalPost.js so dont think this else if statemnt is used
         ev.preventDefault();
         this.closeDialog();
-        create_popup({ title: "Cancel Edit"});
-      } else if(data["popup_title"] == "Cancel Create") {//if a Cancel Create popup, close popup and open new add popup is displayed
+        create_popup({ title: "Cancel Edit" });
+      } else if (data["popup_title"] == "Cancel Create") {
+        //if a Cancel Create popup, close popup and open new add popup is displayed
         ev.preventDefault();
         this.closeDialog();
-        create_popup({ title: "Add", id: data["id"]});
-      } else if(data["popup_title"] == "Cancel Edit") { // is a Cancel Edit popup, close popup show the edit popup
+        create_popup({ title: "Add", id: data["id"] });
+      } else if (data["popup_title"] == "Cancel Edit") {
+        // is a Cancel Edit popup, close popup show the edit popup
         ev.preventDefault();
         this.closeDialog();
         let main = document.querySelector("main");
-        main.lastChild.style.display = 'block';
+        main.lastChild.style.display = "block";
       }
     });
 
@@ -267,7 +276,7 @@ class Popup extends HTMLElement {
     const posts_container = document.querySelector("div.posts");
     posts_container.style.filter = "blur(.25rem)";
   }
-  // closing the dialog 
+  // closing the dialog
   closeDialog() {
     let dialogEl = this.shadowRoot.querySelector("dialog");
     dialogEl.close();


### PR DESCRIPTION
Cancel popups show when cancel button clicked in Add post popup and Edit post popup. Then the user can choose to cancel the cancel of add or edit or continue with the canceling